### PR TITLE
Add [Serializable] attribute to all exceptions.

### DIFF
--- a/src/GraphQL/Execution/ExecutionError.cs
+++ b/src/GraphQL/Execution/ExecutionError.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +8,7 @@ using GraphQLParser;
 
 namespace GraphQL
 {
+    [Serializable]
     public class ExecutionError : Exception
     {
         private List<ErrorLocation> _errorLocations;

--- a/src/GraphQL/Execution/InvalidValueException.cs
+++ b/src/GraphQL/Execution/InvalidValueException.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace GraphQL.Execution
 {
+    [Serializable]
     public class InvalidValueException : ExecutionError
     {
         public InvalidValueException(string fieldName, string message) : 

--- a/src/GraphQL/Validation/ValidationError.cs
+++ b/src/GraphQL/Validation/ValidationError.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using GraphQL.Language.AST;
 using GraphQLParser;
 
 namespace GraphQL.Validation
 {
+    [Serializable]
     public class ValidationError : ExecutionError
     {
         private readonly List<INode> _nodes = new List<INode>();


### PR DESCRIPTION
Newtonsoft.Json 11.0.1 [release notes](https://github.com/JamesNK/Newtonsoft.Json/releases/tag/11.0.1):

> Change - Types that implement ISerializable but don't have [SerializableAttribute] are not serialized using ISerializable

If someone will serialize exception, it will output `TargetSite` property, which has properties of type `Assembly`, etc. Result will be almost 10M per exception, you can use sample below to test.

````
using System;
using Newtonsoft.Json;

namespace Version11
{
    class Program
    {
        static void Main()
        {
            try
            {
                throw new B("123");
            }
            catch (Exception e)
            {
                Console.WriteLine(JsonConvert.SerializeObject(e, new JsonSerializerSettings
                {
                    Formatting = Formatting.Indented,
                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore
                }));
            }
        }
    }

    internal class B : Exception
    {
        public B(string s)
            : base(s)
        {
        }
    }
}
````